### PR TITLE
Fixes #10 - Ignores the project type for SHFB projects

### DIFF
--- a/VersionChanger/Data/SolutionProcessor.cs
+++ b/VersionChanger/Data/SolutionProcessor.cs
@@ -71,10 +71,17 @@ namespace DSoft.VersionChanger.Data
 
                         if (projectTypeGuids != null)
                         {
-                            var ignorableTypes = new List<string>() { "{54435603-DBB4-11D2-8724-00A0C9A8B90C}", "{930C7802-8A8C-48F9-8165-68863BCCD9DD}"};
+                            var ignorableTypes = new List<string>()
+                            {
+                                "{54435603-DBB4-11D2-8724-00A0C9A8B90C}"
+                                , "{930C7802-8A8C-48F9-8165-68863BCCD9DD}"
+                                , "{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}" // Sandcast Help File Builder project 
+                            };
+
+                            var firstTypeId = projectTypeGuids.First().ToUpper();
 
                             //if the type of the project is on the ignore list then skip
-                            if (ignorableTypes.Contains(projectTypeGuids.First().ToUpper()))
+                            if (ignorableTypes.Contains(firstTypeId))
                             {
                                 continue;
                             }
@@ -388,7 +395,7 @@ namespace DSoft.VersionChanger.Data
             {
                 
 
-                if (aItem.ProjectItems.Count > 0)
+                if (aItem.ProjectItems?.Count > 0)
                 {
                     var aResult = FindProjectItem(aItem.ProjectItems, fileName);
 

--- a/VersionChanger/Properties/AssemblyInfo.cs
+++ b/VersionChanger/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
+[assembly: AssemblyVersion("2.3.1.0")]
+[assembly: AssemblyFileVersion("2.3.1.0")]

--- a/VersionChanger/Views/VersionChanger.xaml.cs
+++ b/VersionChanger/Views/VersionChanger.xaml.cs
@@ -65,7 +65,12 @@ namespace DSoft.VersionChanger.Views
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
-           
+           if (mViewModel.Items.Count == 0 && mViewModel.Errors.Count == 0)
+            {
+                MessageBox.Show("There were no compatible projects found in the solution");
+
+                this.DialogResult = true;
+            }
         }
 
         private void FilterClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
 Ignores the project type for SHFB projects and  allows null checks project item.

Also shows a message if no compatible projects are found