### PR TITLE
Version suffix support for semver

### DIFF
--- a/VersionChanger/Data/ProjectVersion.cs
+++ b/VersionChanger/Data/ProjectVersion.cs
@@ -17,6 +17,7 @@ namespace DSoft.VersionChanger.Data
         private Version m_AssemblyVersion;
         private Version mFileVersion;
         private string _version;
+        private string _versionSuffix;
 
         private bool isNewStyleProject;
 
@@ -133,6 +134,20 @@ namespace DSoft.VersionChanger.Data
                 _version = value;
 
                 PropertyDidChange(nameof(PackageVersion));
+            }
+        }
+
+        public string VersionSuffix
+        {
+            get
+            {
+                return _versionSuffix;
+            }
+            set
+            {
+                _versionSuffix = value;
+
+                PropertyDidChange(nameof(VersionSuffix));
             }
         }
 

--- a/VersionChanger/ViewModel/ProjectViewModel.cs
+++ b/VersionChanger/ViewModel/ProjectViewModel.cs
@@ -27,9 +27,10 @@ namespace DSoft.VersionChanger.ViewModel
         private string cocoaShortVersion;
         private DTE mApplication;
         private string androidBuild;
-        private bool selectAll = false;
+        private bool selectAll = true;
         private bool mUpdateClickOnce;
         private bool forceSemVer;
+        private string preRelease;
         private bool _updateNuget;
         private bool _showUnloadedWarning;
         private List<FailedProject> _failedProjects;
@@ -275,7 +276,13 @@ namespace DSoft.VersionChanger.ViewModel
                 SettingsControl.SetBooleanValue(value, "ForceSemVer");
                 PropertyDidChange("ForceSemVer");
                 PropertyDidChange("ShowRevision");
+                PropertyDidChange("ShowSemVer");
             }
+        }
+
+        public bool ShowSemVer
+        {
+            get { return forceSemVer; }
         }
 
         public bool ShowIos
@@ -364,6 +371,12 @@ namespace DSoft.VersionChanger.ViewModel
         {
             get { return androidBuild; }
             set { androidBuild = value; PropertyDidChange("AndroidBuild"); }
+        }
+
+        public string PreRelase
+        {
+            get { return preRelease; }
+            set { preRelease = value; PropertyDidChange("PreRelase"); }
         }
 
         public bool UpdateNuget
@@ -495,12 +508,12 @@ namespace DSoft.VersionChanger.ViewModel
                         {
                             if (ver.IsNewStyleProject == true)
                             {
-                                solutionProcessor.UpdateProject(ver.RealProject, newVersion, fileVersion);
+                                solutionProcessor.UpdateProject(ver.RealProject, newVersion, fileVersion, forceSemVer ? preRelease : null);
 
                             }
                             else
                             {
-                                solutionProcessor.UpdateFile(ver.ProjectItem, newVersion, fileVersion);
+                                solutionProcessor.UpdateFile(ver.ProjectItem, newVersion, fileVersion, forceSemVer ? preRelease : null);
                             }
 
 

--- a/VersionChanger/Views/VersionChanger.xaml
+++ b/VersionChanger/Views/VersionChanger.xaml
@@ -62,6 +62,13 @@
                             </Style>
                         </DataGridTextColumn.ElementStyle>
                     </DataGridTextColumn>
+                    <DataGridTextColumn x:Name="hdrVersionSuffix" Header="VersionSuffix" Width="120" Binding="{Binding VersionSuffix}" IsReadOnly="True">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="{x:Type TextBlock}">
+                                <Setter Property="HorizontalAlignment" Value="Center" />
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                    </DataGridTextColumn>
 
                 </DataGrid.Columns>
             </DataGrid>
@@ -85,7 +92,7 @@
                     <StackPanel Grid.Row="1" VerticalAlignment="Bottom">
                         <CheckBox Margin="5,0,0,5" IsChecked="{Binding UpdateClickOnce}" Content="Update ClickOnce"/>
                         <CheckBox Margin="5,0,0,5" IsChecked="{Binding SeparateVersions}" Content="Use seperate versions"/>
-                        <CheckBox Margin="5,0,0,5" IsChecked="{Binding ForceSemVer}" Content="Use SemVer 2.0" ToolTip="Will use Major, Minor, Build versions only for Assembly and File version. Will update nuget version for new style csproj files"/>
+                        <CheckBox Margin="5,0,0,5" IsChecked="{Binding ForceSemVer}" Checked="CheckBox_Checked" Unchecked="CheckBox_Checked" Content="Use SemVer 2.0" ToolTip="Will use Major, Minor, Build versions only for Assembly and File version. Will update nuget version for new style csproj files"/>
                     </StackPanel>
                 </Grid>
                 <Grid Grid.Column="1" VerticalAlignment="Top" Margin="0,5,0,5">
@@ -167,6 +174,18 @@
                                 Visibility="{Binding ShowRevision, Converter={StaticResource booleanToVisibilityConverter}}"
                                  data:Masking.Mask="^[0-9][\d]*(,\d+)?$"  />
                         </StackPanel>
+                        <Grid VerticalAlignment="Center" x:Name="secPre" Visibility="{Binding ShowSemVer, Converter={StaticResource booleanToVisibilityConverter}}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="0,5,5,0" Width="125" ToolTip="Pre-release label, alphanumberic (+ hyphen) string i.e for beta1 you get 1.0.0-beta1" >VersionSuffix (optional)</TextBlock>
+                            <TextBox  Grid.Column="1"
+                                 Text="{Binding PreRelase}" 
+                                 Margin="0,5,0,0" 
+                                 TextAlignment="Right" 
+                                 data:Masking.Mask="^[0-9A-Za-z-]*$"  />
+                        </Grid>
                         <Grid VerticalAlignment="Center" x:Name="secIos" Visibility="{Binding ShowIos, Converter={StaticResource booleanToVisibilityConverter}}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>

--- a/VersionChanger/Views/VersionChanger.xaml.cs
+++ b/VersionChanger/Views/VersionChanger.xaml.cs
@@ -35,6 +35,8 @@ namespace DSoft.VersionChanger.Views
             mViewModel = new ProjectViewModel(applicationObject);
 
             this.DataContext = mViewModel;
+
+            CheckBox_Checked(this, null);
         }
 
         private void OnBeginClicked(object sender, RoutedEventArgs e)
@@ -76,6 +78,11 @@ namespace DSoft.VersionChanger.Views
         private void FilterClick(object sender, RoutedEventArgs e)
         {
             mViewModel.FilterProjects();
+        }
+
+        private void CheckBox_Checked(object sender, RoutedEventArgs e)
+        {
+            hdrVersionSuffix.Visibility = mViewModel.ShowSemVer ? Visibility.Visible : Visibility.Hidden;
         }
     }
 }

--- a/VersionChanger/source.extension.vsixmanifest
+++ b/VersionChanger/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="VersionChanger.315c8ff9-932e-4b23-b9d8-0fcd23bdb0be" Version="2.3.2" Language="en-US" Publisher="DSoft Developments" />
+        <Identity Id="VersionChanger.315c8ff9-932e-4b23-b9d8-0fcd23bdb0be" Version="2.3.3" Language="en-US" Publisher="DSoft Developments" />
         <DisplayName>Version Changer</DisplayName>
         <Description xml:space="preserve">Visual Studio extension that allows you to change the version number of all projects in a solution in a easy to user interface.</Description>
         <MoreInfo>https://visualstudiogallery.msdn.microsoft.com/554c35ef-fe76-4138-b60e-a44b72ade70e</MoreInfo>


### PR DESCRIPTION
I've added support for setting version suffix when using semver2. With this change we can set pre-release info for assembly.
In the old style project suffix is stored in AssemblyInformationalVersion attribute on the AssemblyProperties.cs file.