### PR TITLE
v4.1.3

### DIFF
--- a/VersionChanger/Data/ProjectVersionCollection.cs
+++ b/VersionChanger/Data/ProjectVersionCollection.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Runtime.Remoting;
 
@@ -8,6 +10,8 @@ namespace DSoft.VersionChanger.Data
 {
 	public class ProjectVersionCollection : ObservableCollection<ProjectVersion>
 	{
+		public event EventHandler<bool> SelectionStateChanged = delegate { };
+
 		public bool HasAndroid
 		{
 			get;
@@ -86,7 +90,8 @@ namespace DSoft.VersionChanger.Data
 
 		public ProjectVersionCollection()
 		{
-		}
+
+        }
 
         internal void UpdateState(Dictionary<string, bool> dict)
         {
@@ -97,6 +102,20 @@ namespace DSoft.VersionChanger.Data
 					item.Update = dict[item.Name];
 				}
 			}
+        }
+
+		public void WireUpEvents()
+		{
+            foreach (INotifyPropertyChanged item in Items)
+                item.PropertyChanged += OnItemPropertyChanged;
+        }
+
+        private void OnItemPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName.Equals(nameof(ProjectVersion.Update)))
+            {
+				SelectionStateChanged(sender, true);
+            }
         }
     }
 }

--- a/VersionChanger/Data/ProjectVersionCollection.cs
+++ b/VersionChanger/Data/ProjectVersionCollection.cs
@@ -93,15 +93,23 @@ namespace DSoft.VersionChanger.Data
 
         }
 
-        internal void UpdateState(Dictionary<string, bool> dict)
+        internal bool UpdateState(Dictionary<string, bool> dict)
         {
+			var result = false;
+
 			foreach (var item in Items)
 			{
 				if (dict.ContainsKey(item.Name))
 				{
 					item.Update = dict[item.Name];
 				}
+				else
+				{
+					result = true;
+				}
 			}
+			
+			return result;
         }
 
 		public void WireUpEvents()

--- a/VersionChanger/Resources/Changes.txt
+++ b/VersionChanger/Resources/Changes.txt
@@ -1,4 +1,8 @@
-﻿Changes in 4.1.2
+﻿Changes in 4.1.3
+  - Added ability to disable storing of the project selection state(for when it is causing a crash)
+  - Updated the logic for storing of the project selection state to make it more stable and efficient(will now only save when changes to the selections have been made)
+  - Updated manifest to correctly point to the 2022 version of the extension on Marketplace
+Changes in 4.1.2
   - Added remembering of the project selection
   - Fixed issue with file Revision when using separate versions and revision is disabled
 Changes in 4.1.1

--- a/VersionChanger/Resources/MarketplaceText_2022.html
+++ b/VersionChanger/Resources/MarketplaceText_2022.html
@@ -44,6 +44,14 @@
    <h2>Release Notes</h2>
    <ul>
        <li>
+           Version 4.1.3
+           <ul>
+               <li>Added ability to disable storing of the project selection state(for when it is causing a crash)</li>
+               <li>Updated the logic for storing of the project selection state to make it more stable and efficient(will now only save when changes to the selections have been made)</li>
+               <li>Updated manifest to correctly point to the 2022 version of the extension on Marketplace</li>
+           </ul>
+       </li>
+       <li>
            Version 4.1.2
            <ul>
                <li>Added remembering of the project selection</li>

--- a/VersionChanger/ViewModel/ProjectViewModel.cs
+++ b/VersionChanger/ViewModel/ProjectViewModel.cs
@@ -681,6 +681,8 @@ namespace DSoft.VersionChanger.ViewModel
 
                 LoadAssFileVersion();
 
+                var selectionStateChanged = false;
+
                 if (!DisableSelectionStorage)
                 {
                     try
@@ -691,7 +693,8 @@ namespace DSoft.VersionChanger.ViewModel
                         {
                             var dict = stateStream.Deserialize();
 
-                            Items.UpdateState(dict);
+                            //selection state will change if there are new projects that haven't been stored before
+                            selectionStateChanged = Items.UpdateState(dict);
 
                         }
                     }
@@ -703,7 +706,7 @@ namespace DSoft.VersionChanger.ViewModel
 
                 Items.WireUpEvents();
                 Items.SelectionStateChanged += OnItemSelectionStateUpdated;
-                _selectionStateHasChanged = false;
+                _selectionStateHasChanged = selectionStateChanged;
                 IsLoaded = true;
                 LoadingProjectsText = "Preparing....";
                 CurrentProjectName = string.Empty;

--- a/VersionChanger/ViewModel/ProjectViewModel.cs
+++ b/VersionChanger/ViewModel/ProjectViewModel.cs
@@ -35,6 +35,7 @@ namespace DSoft.VersionChanger.ViewModel
         private bool _updateNuget;
         private bool _showUnloadedWarning;
         private List<FailedProject> _failedProjects;
+        private bool _selectionStateHasChanged;
 
         private string _assemblyMajor;
         private string _assemblyRevision;
@@ -53,6 +54,7 @@ namespace DSoft.VersionChanger.ViewModel
         private int _currentProject;
         private string _currentProjectName;
         private string _workingText = "Loading...";
+        private bool _disableSelectionStorage;
         #endregion
 
         public event EventHandler LoadingProgressUpdated = delegate { };
@@ -511,6 +513,17 @@ namespace DSoft.VersionChanger.ViewModel
             }
         }
 
+        public bool DisableSelectionStorage
+        {
+            get { return _disableSelectionStorage; }
+            set
+            {
+                _disableSelectionStorage = value;
+                SettingsControl.SetBooleanValue(value, "DisableSelectionStorage");
+                PropertyDidChange("DisableSelectionStorage");
+            }
+        }
+
         public bool UpdateAppDisplayVersion
         {
             get { return _versionOptions.UpdateAppDisplayVersion; }
@@ -590,6 +603,7 @@ namespace DSoft.VersionChanger.ViewModel
             _forceSemVer = SettingsControl.GetBooleanValue("ForceSemVer");
             _updateNuget = SettingsControl.GetBooleanValue("UpdateNuget");
             _versionOptions.EnableRevision = SettingsControl.GetBooleanValue("EnableRevision", true);
+            _disableSelectionStorage = SettingsControl.GetBooleanValue("DisableSelectionStorage", false);
 
             if (_forceSemVer == true)
             {
@@ -663,30 +677,33 @@ namespace DSoft.VersionChanger.ViewModel
                     }
                 }
 
-
                 LoadAssVersion();
 
                 LoadAssFileVersion();
 
-
-
-                try
+                if (!DisableSelectionStorage)
                 {
-                    var stateStream = SettingsControl.GetStreamValue("ProjectState");
-
-                    if (stateStream != null && stateStream.Length > 0)
+                    try
                     {
-                        var dict = stateStream.Deserialize();
+                        var stateStream = SettingsControl.GetStreamValue("ProjectState");
 
-                        Items.UpdateState(dict);
+                        if (stateStream != null && stateStream.Length > 0)
+                        {
+                            var dict = stateStream.Deserialize();
 
+                            Items.UpdateState(dict);
+
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        //unable to reload the project state
                     }
                 }
-                catch (Exception ex)
-                {
-                    //unable to relaod the project state
-                }
 
+                Items.WireUpEvents();
+                Items.SelectionStateChanged += OnItemSelectionStateUpdated;
+                _selectionStateHasChanged = false;
                 IsLoaded = true;
                 LoadingProjectsText = "Preparing....";
                 CurrentProjectName = string.Empty;
@@ -697,6 +714,11 @@ namespace DSoft.VersionChanger.ViewModel
                 System.Windows.MessageBox.Show(ex.Message, "Error loading projects");
 			}
 
+        }
+
+        private void OnItemSelectionStateUpdated(object sender, bool e)
+        {
+            _selectionStateHasChanged = true;
         }
 
         public void ProcessUpdates()
@@ -971,11 +993,15 @@ namespace DSoft.VersionChanger.ViewModel
 
         public void SaveProjectSelection()
         {
-            //store the selection state of the projects
-            var stateDict = Items.StateDictionary;
+
+            if (!_selectionStateHasChanged)
+                return;
 
             try
             {
+                //store the selection state of the projects
+                var stateDict = Items.StateDictionary;
+
                 var stream = new MemoryStream();
 
                 stateDict.Serialize(stream);

--- a/VersionChanger/Views/VersionChanger.xaml
+++ b/VersionChanger/Views/VersionChanger.xaml
@@ -262,6 +262,7 @@
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition />
                                         <ColumnDefinition />
+                                        <ColumnDefinition />
                                     </Grid.ColumnDefinitions>
                                     <StackPanel>
                                         <CheckBox Margin="5,5,0,5" IsChecked="{Binding UpdateClickOnce}" Content="Update ClickOnce" ToolTip="Update clickonce version numbers"/>
@@ -269,6 +270,9 @@
                                         <CheckBox Margin="5,0,0,10" IsChecked="{Binding ForceSemVer}" Checked="OnUseSemVerChecked" Unchecked="OnUseSemVerChecked" Content="Use SemVer 2.0" ToolTip="Will use Major, Minor, Build versions only for Assembly and File version. Will update nuget version for new style csproj files. Disbales 'Enable Revision'"/>
                                     </StackPanel>
                                     <StackPanel Grid.Column="1" HorizontalAlignment="Right">
+                                        <CheckBox Margin="0,5,5,5" IsChecked="{Binding DisableSelectionStorage}" Content="Disable saving selection state" ToolTip="Disable storing selection state.  Use this if there are any crashes when closing the Version Changer window"/>
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="2" HorizontalAlignment="Right">
                                         <CheckBox Margin="0,5,5,5" IsChecked="{Binding EnableRevision}" Content="Enable Revision" IsEnabled="{Binding EnableRevisionEnabled}" ToolTip="Enable revision version field"/>
                                     </StackPanel>
                                 </Grid>

--- a/VersionChanger/Views/VersionChanger.xaml.cs
+++ b/VersionChanger/Views/VersionChanger.xaml.cs
@@ -169,9 +169,17 @@ namespace DSoft.VersionChanger.Views
 
         }
 
-        private void OnClosing(object sender, System.ComponentModel.CancelEventArgs e)
+        private async void OnClosing(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            _viewModel.SaveProjectSelection();
+            if (!_viewModel.DisableSelectionStorage)
+            {
+                await Task.Run(() =>
+                {
+                    _viewModel.SaveProjectSelection();
+                });
+            }
+
         }
+
     }
 }

--- a/VersionChanger/source.extension.vsixmanifest
+++ b/VersionChanger/source.extension.vsixmanifest
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="VersionChanger2022.315c8ff9-932e-4b23-b9d8-0fcd23bdb0be" Version="4.1.2" Language="en-US" Publisher="Newky2k" />
+        <Identity Id="VersionChanger2022.315c8ff9-932e-4b23-b9d8-0fcd23bdb0be" Version="4.1.3" Language="en-US" Publisher="Newky2k" />
         <DisplayName>Version Changer 2022</DisplayName>
         <Description xml:space="preserve">Visual Studio 2022 extension that allows you to change the version numbers in all projects in a solution in a easy to use interface.</Description>
-        <MoreInfo>https://visualstudiogallery.msdn.microsoft.com/554c35ef-fe76-4138-b60e-a44b72ade70e</MoreInfo>
+        <MoreInfo>https://marketplace.visualstudio.com/items?itemName=Newky2k.VersionChanger2022</MoreInfo>
         <ReleaseNotes>Changes.txt</ReleaseNotes>
         <Icon>Resources\Package.ico</Icon>
     </Metadata>


### PR DESCRIPTION
  - Added ability to disable storing of the project selection state(for when it is causing a crash)
  - Updated the logic for storing of the project selection state to make it more stable and efficient(will now only save when changes to the selections have been made)
  - Updated manifest to correctly point to the 2022 version of the extension on Marketplace