### PR TITLE
Feature assembly file version add suffix

### DIFF
--- a/VersionChanger/Data/SolutionProcessor.cs
+++ b/VersionChanger/Data/SolutionProcessor.cs
@@ -367,7 +367,7 @@ namespace DSoft.VersionChanger.Data
         /// <param name="item">The item.</param>
         /// <param name="newAssemblyVersion">The new assembly version.</param>
         /// <param name="newFileVersion">The new file version.</param>
-        public void UpdateFrameworkProject(ProjectItem item, AssemblyVersionOptions versionOptions, Version newAssemblyVersion, Version newFileVersion = null, string versionSuffix = null)
+        public void UpdateFrameworkProject(ProjectItem item, AssemblyVersionOptions versionOptions, Version newAssemblyVersion, Version newFileVersion = null, string versionSuffix = null, bool assemblyFileInfo_AddSuffix = false)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
@@ -451,8 +451,12 @@ namespace DSoft.VersionChanger.Data
                             int locationEnd = remaining.IndexOf("\"");
                             string end = remaining.Substring(locationEnd);
 
-
-                            var newFileVersionValue = versionOptions.CalculateVersion(newFileVersion);
+                            string newFileVersionValue;
+                            if (assemblyFileInfo_AddSuffix == true)
+                            {
+                                newFileVersionValue = versionOptions.CalculateVersion(newFileVersion, versionSuffix);
+                            }
+                            else newFileVersionValue = versionOptions.CalculateVersion(newFileVersion);
 
                             var newLine = string.Format("{0}{1}{2}", firstBit, newFileVersionValue.ToString(), end);
 

--- a/VersionChanger/ViewModel/ProjectViewModel.cs
+++ b/VersionChanger/ViewModel/ProjectViewModel.cs
@@ -55,6 +55,7 @@ namespace DSoft.VersionChanger.ViewModel
         private string _currentProjectName;
         private string _workingText = "Loading...";
         private bool _disableSelectionStorage;
+        private bool _assemblyFileInfo_AddSuffix;
         #endregion
 
         public event EventHandler LoadingProgressUpdated = delegate { };
@@ -292,11 +293,13 @@ namespace DSoft.VersionChanger.ViewModel
 
                 if (_forceSemVer == true)
                     EnableRevision = false;
+                else AssemblyFileInfo_AddSuffix = false;
 
                 PropertyDidChange("ForceSemVer");
                 PropertyDidChange("ShowRevision");
                 PropertyDidChange("ShowSemVer");
                 PropertyDidChange("EnableRevisionEnabled");
+                PropertyDidChange("AssemblyFileInfo_AddSuffix");
             }
         }
 
@@ -524,6 +527,17 @@ namespace DSoft.VersionChanger.ViewModel
             }
         }
 
+        public bool AssemblyFileInfo_AddSuffix
+        {
+            get { return _assemblyFileInfo_AddSuffix; }
+            set
+            {
+                _assemblyFileInfo_AddSuffix = value;
+                SettingsControl.SetBooleanValue(value, "AssemblyFileInfo_AddSuffix");
+                PropertyDidChange("AssemblyFileInfo_AddSuffix");
+            }
+        }
+
         public bool UpdateAppDisplayVersion
         {
             get { return _versionOptions.UpdateAppDisplayVersion; }
@@ -604,10 +618,15 @@ namespace DSoft.VersionChanger.ViewModel
             _updateNuget = SettingsControl.GetBooleanValue("UpdateNuget");
             _versionOptions.EnableRevision = SettingsControl.GetBooleanValue("EnableRevision", true);
             _disableSelectionStorage = SettingsControl.GetBooleanValue("DisableSelectionStorage", false);
+            _assemblyFileInfo_AddSuffix = SettingsControl.GetBooleanValue("AssemblyFileInfo_AddSuffix", false);
 
             if (_forceSemVer == true)
             {
                 _versionOptions.EnableRevision = false;
+            }
+            else
+            {
+                _assemblyFileInfo_AddSuffix = false;
             }
 
             _versionOptions.UpdateAssemblyVersion = SettingsControl.GetBooleanValue("UpdateAssemblyVersion", true);
@@ -788,7 +807,7 @@ namespace DSoft.VersionChanger.ViewModel
                             }
                             else
                             {
-                                solutionProcessor.UpdateFrameworkProject(ver.ProjectItem, _versionOptions, newVersion, fileVersion, _forceSemVer ? preRelease : null);
+                                solutionProcessor.UpdateFrameworkProject(ver.ProjectItem, _versionOptions, newVersion, fileVersion, _forceSemVer ? preRelease : null, _assemblyFileInfo_AddSuffix);
                             }
 
 

--- a/VersionChanger/Views/VersionChanger.xaml
+++ b/VersionChanger/Views/VersionChanger.xaml
@@ -267,10 +267,11 @@
                                     <StackPanel>
                                         <CheckBox Margin="5,5,0,5" IsChecked="{Binding UpdateClickOnce}" Content="Update ClickOnce" ToolTip="Update clickonce version numbers"/>
                                         <CheckBox Margin="5,0,0,5" IsChecked="{Binding SeparateVersions}" Content="Use seperate versions" Checked="OnUseSeperateVersionsChanged" Unchecked="OnUseSeperateVersionsChanged" ToolTip="Use different assembly and file versions"/>
-                                        <CheckBox Margin="5,0,0,10" IsChecked="{Binding ForceSemVer}" Checked="OnUseSemVerChecked" Unchecked="OnUseSemVerChecked" Content="Use SemVer 2.0" ToolTip="Will use Major, Minor, Build versions only for Assembly and File version. Will update nuget version for new style csproj files. Disbales 'Enable Revision'"/>
+                                        <CheckBox Margin="5,0,0,10" IsChecked="{Binding ForceSemVer}" Checked="OnUseSemVerChecked" Unchecked="OnUseSemVerChecked" Content="Use SemVer 2.0" ToolTip="Will use Major, Minor, Build versions only for Assembly and File version. Will update nuget version for new style csproj files. Disables 'Enable Revision'. Enables 'Suffix in file version'"/>
                                     </StackPanel>
                                     <StackPanel Grid.Column="1" HorizontalAlignment="Right">
                                         <CheckBox Margin="0,5,5,5" IsChecked="{Binding DisableSelectionStorage}" Content="Disable saving selection state" ToolTip="Disable storing selection state.  Use this if there are any crashes when closing the Version Changer window"/>
+                                        <CheckBox Margin="0,5,5,5" IsChecked="{Binding AssemblyFileInfo_AddSuffix}" Content="Suffix in AssemblyFileVersion" ToolTip="Adds version suffix to AssemblyFileInfo property (.NET Framework)" IsEnabled="{Binding ForceSemVer}" />
                                     </StackPanel>
                                     <StackPanel Grid.Column="2" HorizontalAlignment="Right">
                                         <CheckBox Margin="0,5,5,5" IsChecked="{Binding EnableRevision}" Content="Enable Revision" IsEnabled="{Binding EnableRevisionEnabled}" ToolTip="Enable revision version field"/>

--- a/VersionChanger/Views/VersionChanger.xaml
+++ b/VersionChanger/Views/VersionChanger.xaml
@@ -267,7 +267,7 @@
                                     <StackPanel>
                                         <CheckBox Margin="5,5,0,5" IsChecked="{Binding UpdateClickOnce}" Content="Update ClickOnce" ToolTip="Update clickonce version numbers"/>
                                         <CheckBox Margin="5,0,0,5" IsChecked="{Binding SeparateVersions}" Content="Use seperate versions" Checked="OnUseSeperateVersionsChanged" Unchecked="OnUseSeperateVersionsChanged" ToolTip="Use different assembly and file versions"/>
-                                        <CheckBox Margin="5,0,0,10" IsChecked="{Binding ForceSemVer}" Checked="OnUseSemVerChecked" Unchecked="OnUseSemVerChecked" Content="Use SemVer 2.0" ToolTip="Will use Major, Minor, Build versions only for Assembly and File version. Will update nuget version for new style csproj files. Disables 'Enable Revision'. Enables 'Suffix in file version'"/>
+                                        <CheckBox Margin="5,0,0,10" IsChecked="{Binding ForceSemVer}" Checked="OnUseSemVerChecked" Unchecked="OnUseSemVerChecked" Content="Use SemVer 2.0" ToolTip="Will use Major, Minor, Build versions only for Assembly and File version. Will update nuget version for new style csproj files. Disables 'Enable Revision'. Enables 'Suffix in AssemblyFileVersion'"/>
                                     </StackPanel>
                                     <StackPanel Grid.Column="1" HorizontalAlignment="Right">
                                         <CheckBox Margin="0,5,5,5" IsChecked="{Binding DisableSelectionStorage}" Content="Disable saving selection state" ToolTip="Disable storing selection state.  Use this if there are any crashes when closing the Version Changer window"/>


### PR DESCRIPTION
Added new option "Suffix in AssemblyFileVersion". When checked, the 'AssemblyFileVersion' property in the AssemblyInfo.cs file (only .NET Framework projects) will be updated with the new version number including the provided version suffix.

This is useful, because the 'AssemblyInformationalVersion' property is not automatically created in the AssemblyInfo.cs when creating a new Framework project and will therefore also not be updated when using VersionChanger. If you want your version suffix to show up in the properties of your project dll, you would need to manually create a new line in the AssemblyInfo.cs file.

Instead you can use this option to write the suffix into the 'AssemblyFileVersion' property, which is automatically created with each new project. When building the project, VS automatically sets the 'AssemblyInformationalVersion' value to the 'AssemblyFileVersion' value and cuts off the suffix from the 'AssemblyFileVersion'. This allows you to use VersionChanger to add suffixes to your versions without having to change your project.